### PR TITLE
Passing full list of argv to Execve function

### DIFF
--- a/cmd/assume-role-arn/main.go
+++ b/cmd/assume-role-arn/main.go
@@ -91,7 +91,7 @@ func runCommand(args []string) error {
 		panic(err)
 	}
 
-	return syscall.Exec(binary, args[1:], env)
+	return syscall.Exec(binary, args, env)
 }
 
 func main() {


### PR DESCRIPTION
execve called by syscall.Exec expected that the argv[0] should contain the filename associated with the file being executed. 
ref: http://man7.org/linux/man-pages/man2/execve.2.html