### PR TITLE
Handle expired credentials

### DIFF
--- a/cmd/assume-role-arn/main.go
+++ b/cmd/assume-role-arn/main.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
 )
@@ -88,7 +89,26 @@ func getSession() *session.Session {
 
 func assumeRole(sess *session.Session, input *sts.AssumeRoleInput) (*sts.AssumeRoleOutput, error) {
 	svc := sts.New(sess)
-	return svc.AssumeRole(input)
+
+	role, err := svc.AssumeRole(input)
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok {
+			if awsErr.Code() == "ExpiredToken" {
+				os.Unsetenv("AWS_ACCESS_KEY_ID")
+				os.Unsetenv("AWS_SECRET_ACCESS_KEY")
+				os.Unsetenv("AWS_SESSION_TOKEN")
+
+				// Reinitialize session because env vars have changed.
+				sess = getSession()
+				svc = sts.New(sess)
+
+				return svc.AssumeRole(input)
+			}
+		}
+		return nil, err
+	}
+
+	return role, nil
 }
 
 func printExport(val *sts.AssumeRoleOutput) {


### PR DESCRIPTION
If ExpiredToken error is returned unset the credentials variables and
retry request.