### PR TITLE
Fix caching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 build: build-linux build-osx
 
 build-linux:
-	GOOS=linux go build -o bin/assume-role-arn-linux cmd/assume-role-arn/*.go
+	CGO_ENABLED=0 GOOS=linux go build -o bin/assume-role-arn-linux cmd/assume-role-arn/*.go
 
 build-osx:
-	GOOS=darwin go build -o bin/assume-role-arn-osx cmd/assume-role-arn/*.go
+	CGO_ENABLED=0 GOOS=darwin go build -o bin/assume-role-arn-osx cmd/assume-role-arn/*.go

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Available flags:
 *  `-mfatoken token` - optional, the MFA token
 *  `-profile profile_name` - the name of AWS profile (from $HOME/.aws/config)
 *  `-ignoreCache` - ignore the credentials stored in the cache
+*  `-skipCache` - skip the credential cache
 *  `-h` - help
 
 ## CI/CD pipeline example

--- a/cmd/assume-role-arn/creds_cache.go
+++ b/cmd/assume-role-arn/creds_cache.go
@@ -13,10 +13,7 @@ import (
 
 const (
 	expirationTimeDelta = 60 * time.Minute
-)
-
-var (
-	defaultCacheDir = "assume-role-arn"
+	defaultCacheDir     = "assume-role-arn"
 )
 
 type AWSCreds struct {

--- a/cmd/assume-role-arn/main.go
+++ b/cmd/assume-role-arn/main.go
@@ -255,7 +255,7 @@ func main() {
 		setEnv(creds)
 		err := runCommand(flag.Args())
 		if err != nil {
-			logrus.WithError(err).WithFields(logrus.Fields{"cmd_args": flag.Args()}).Fatal("failed to ru command")
+			logrus.WithError(err).WithFields(logrus.Fields{"cmd_args": flag.Args()}).Fatal("failed to run the command")
 		}
 	} else {
 		printExport(creds)

--- a/cmd/assume-role-arn/main.go
+++ b/cmd/assume-role-arn/main.go
@@ -212,14 +212,14 @@ func main() {
 
 	sessionHash := getSessionHash(roleARN, awsProfileName)
 
-	var credsCache CredsCache
+	var credsCache CredentialsCacher
 	if skipCache {
-		credsCache = new(DummyCredsCache)
+		credsCache = &DummyCredentialsCache{}
 	} else {
-		credsCache = new(FileCredsCache)
+		credsCache = &FileCredentialsCache{}
 	}
 
-	creds, err := credsCache.ReadCreds(sessionHash)
+	creds, err := credsCache.Read(sessionHash)
 	if err != nil {
 		panic(err)
 	}
@@ -234,8 +234,8 @@ func main() {
 			panic(err)
 		}
 		logrus.WithField("creds", creds).Debug("write credentials")
-		if err := credsCache.WriteCreds(sessionHash, creds); err != nil {
-			logrus.WithError(err).Warning("unable to cache credentials")
+		if err := credsCache.Write(sessionHash, creds); err != nil {
+			logrus.WithError(err).Error("unable to cache credentials")
 		}
 	} else {
 		sess := getSession(creds)
@@ -247,8 +247,8 @@ func main() {
 			if err != nil {
 				panic(err)
 			}
-			if err := credsCache.WriteCreds(sessionHash, creds); err != nil {
-				logrus.WithError(err).Warning("unable to cache credentials")
+			if err := credsCache.Write(sessionHash, creds); err != nil {
+				logrus.WithError(err).Error("unable to cache credentials")
 			}
 		}
 	}


### PR DESCRIPTION
Added option to completely skip the caching of credentials. Changed the error to a warning if the credentials cannot be stored in the file.