### PR TITLE
Allow to specify custom AWS region

### DIFF
--- a/cmd/assume-role-arn/main.go
+++ b/cmd/assume-role-arn/main.go
@@ -24,8 +24,8 @@ const (
 )
 
 var (
-	roleARN, roleName, externalID, mfa, mfaToken, awsProfileName string
-	verbose, ignoreCache, skipCache, version                     bool
+	roleARN, roleName, externalID, mfa, mfaToken, region, awsProfileName string
+	verbose, ignoreCache, skipCache, version                             bool
 )
 
 func init() {
@@ -45,6 +45,7 @@ func init() {
 	flag.StringVar(&mfa, "m", "", "MFA serial (shorthand)")
 
 	flag.StringVar(&mfaToken, "mfatoken", "", "MFA token")
+	flag.StringVar(&region, "region", "", "AWS region")
 
 	flag.BoolVar(&verbose, "verbose", false, "verbose mode")
 	flag.BoolVar(&verbose, "v", false, "verbose mode (shorthand)")
@@ -89,12 +90,15 @@ func askForMFAToken(roleARN string) string {
 }
 
 func getRegion() string {
-	region := os.Getenv(envAWSDefaultRegion)
-	if region == "" {
-		return defaultRegion
+	if region != "" {
+		return region
 	}
 
-	return region
+	if region := os.Getenv(envAWSDefaultRegion); region != "" {
+		return region
+	}
+
+	return defaultRegion
 }
 
 func getSession(awsCreds *AWSCreds) *session.Session {
@@ -105,6 +109,7 @@ func getSession(awsCreds *AWSCreds) *session.Session {
 			Region: aws.String(region),
 		},
 	}
+
 	if awsProfileName != "" {
 		awsProfile, _ := readAWSProfile(awsProfileName)
 		logrus.WithFields(logrus.Fields{"awsProfile": awsProfile, "profileName": awsProfileName}).Debug("aws profile")

--- a/cmd/assume-role-arn/main.go
+++ b/cmd/assume-role-arn/main.go
@@ -18,9 +18,14 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	envAWSDefaultRegion = "AWS_DEFAULT_REGION"
+	defaultRegion       = "us-east-1"
+)
+
 var (
 	roleARN, roleName, externalID, mfa, mfaToken, awsProfileName string
-	verbose, ignoreCache, skipCache, version                              bool
+	verbose, ignoreCache, skipCache, version                     bool
 )
 
 func init() {
@@ -83,8 +88,17 @@ func askForMFAToken(roleARN string) string {
 	return strings.TrimRight(mfaToken, "\n")
 }
 
+func getRegion() string {
+	region := os.Getenv(envAWSDefaultRegion)
+	if region == "" {
+		return defaultRegion
+	}
+
+	return region
+}
+
 func getSession(awsCreds *AWSCreds) *session.Session {
-	region := "us-east-1"
+	region := getRegion()
 	sessionOptions := session.Options{
 		SharedConfigState: session.SharedConfigEnable,
 		Config: aws.Config{
@@ -233,7 +247,7 @@ func main() {
 	}
 
 	sessionHash := getSessionHash(roleARN, awsProfileName)
-	
+
 	var credsCache CredentialsCacher = &FileCredentialsCache{}
 	if skipCache {
 		credsCache = &DummyCredentialsCache{}


### PR DESCRIPTION
Specifying a custom region for assuming an IAM role in general is not necessary as STS service is available at a global endpoint. However when assuming a role in AWS China the region must be provided so the SDK will determined the correct endpoint.