### PR TITLE
Add build for M1 osx chip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.15.x
+- 1.17.x
 env:
 - GO111MODULE=on CGO_ENABLED=0
 git:
@@ -21,6 +21,7 @@ deploy:
   file: 
   - bin/assume-role-arn-linux
   - bin/assume-role-arn-osx
+  - bin/assume-role-arn-osx-arm
   on:
     tags: true
     repo: nordcloud/assume-role-arn

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,13 @@ CHANGES := $(shell test -n "$$(git status --porcelain)" && echo '+CHANGES' || tr
 
 LDFLAGS := -X main.Revision=$(REVISION)$(CHANGES) -X main.Version=$(TRAVIS_TAG)
 
-build: build-linux build-osx
+build: build-linux build-osx build-osx-arm
 
 build-linux:
 	@ GOOS=linux go build -ldflags="$(LDFLAGS)" -o bin/assume-role-arn-linux cmd/assume-role-arn/*.go
 
 build-osx:
 	@ GOOS=darwin go build -ldflags="$(LDFLAGS)" -o bin/assume-role-arn-osx cmd/assume-role-arn/*.go
+
+build-osx-arm:
+	@ GOOS=darwin GOARCH=arm64 go build -ldflags="$(LDFLAGS)" -o bin/assume-role-arn-osx-arm cmd/assume-role-arn/*.go

--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,6 @@ require (
 	github.com/aws/aws-sdk-go v1.37.30
 	github.com/sirupsen/logrus v1.8.1
 	github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337 // indirect
+	golang.org/x/sys v0.1.0 // indirect
 	gopkg.in/ini.v1 v1.62.0
 )

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=


### PR DESCRIPTION
- Added golang.org/x/sys to dependencies to build on go 1.18+ on arm64
- Changed Makefile 
- Changed Travis 

Fixes #87 