### PR TITLE
Build static binaries so this will work on busybox/non-gcc libc environments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@ LDFLAGS := -X main.Revision=$(REVISION)$(CHANGES) -X main.Version=$(TRAVIS_TAG)
 build: build-linux build-osx build-osx-arm
 
 build-linux:
-	@ GOOS=linux go build -ldflags="$(LDFLAGS)" -o bin/assume-role-arn-linux cmd/assume-role-arn/*.go
+	@ GOOS=linux CGO_ENABLED=0 go build -ldflags="$(LDFLAGS)" -o bin/assume-role-arn-linux cmd/assume-role-arn/*.go
 
 build-osx:
-	@ GOOS=darwin go build -ldflags="$(LDFLAGS)" -o bin/assume-role-arn-osx cmd/assume-role-arn/*.go
+	@ GOOS=darwin CGO_ENABLED=0 go build -ldflags="$(LDFLAGS)" -o bin/assume-role-arn-osx cmd/assume-role-arn/*.go
 
 build-osx-arm:
-	@ GOOS=darwin GOARCH=arm64 go build -ldflags="$(LDFLAGS)" -o bin/assume-role-arn-osx-arm cmd/assume-role-arn/*.go
+	@ GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -ldflags="$(LDFLAGS)" -o bin/assume-role-arn-osx-arm cmd/assume-role-arn/*.go


### PR DESCRIPTION
Doesn't seem to be any C dependencies in the project, and quick smoke test seems good.

This will enable the tool to be used on minimal non-gcc libc environments such as busybox, alpine and the like.